### PR TITLE
replaces "error in yaml" with "error in file <FILENAME>" (upstream pr #664)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
@@ -32,7 +32,7 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
             try {
                 parsedYaml = yaml.loadAs(changeLogStream, Map.class);
             } catch (Exception e) {
-                throw new ChangeLogParseException("Syntax error in " + getSupportedFileExtensions()[0] + ": " + e.getMessage(), e);
+                throw new ChangeLogParseException("Syntax error in file " + physicalChangeLogLocation + ": " + e.getMessage(), e);
             }
 
             if (parsedYaml == null || parsedYaml.size() == 0) {

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -287,7 +287,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
 
         then:
         def e = thrown(ChangeLogParseException)
-        assert e.message.startsWith("Syntax error in yaml")
+        assert e.message.startsWith("Syntax error in file liquibase/parser/core/yaml/malformedChangeLog.yaml")
     }
 
     def "elements that don't correspond to anything in liquibase are ignored"() throws Exception {


### PR DESCRIPTION
…ocating of invalid yaml file when using "includeAll" (CORE-3013)