### PR TITLE
Revert "CORE-3010 MySQL Add Default Value failed (upstream pr #660)"

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGeneratorMySQL.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGeneratorMySQL.java
@@ -3,11 +3,9 @@ package liquibase.sqlgenerator.core;
 import liquibase.database.Database;
 import liquibase.structure.core.Schema;
 import liquibase.datatype.DataTypeFactory;
-import liquibase.exception.ValidationErrors;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
-import liquibase.util.StringUtils;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -25,21 +23,10 @@ public class AddDefaultValueGeneratorMySQL extends AddDefaultValueGenerator {
     }
 
     @Override
-    public ValidationErrors validate(AddDefaultValueStatement addDefaultValueStatement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-    	ValidationErrors validationErrors;
-    	
-    	validationErrors = super.validate(addDefaultValueStatement, database, sqlGeneratorChain);
-    	
-        validationErrors.checkRequiredField("columnDataType", StringUtils.trimToNull(addDefaultValueStatement.getColumnDataType()));
-
-        return validationErrors;
-    }
-    
-    @Override
     public Sql[] generateSql(AddDefaultValueStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         Object defaultValue = statement.getDefaultValue();
         return new Sql[]{
-                new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType(), database).toDatabaseDataType(database) + " DEFAULT " + DataTypeFactory.getInstance().fromObject(defaultValue, database).objectToSql(defaultValue, database),
+                new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " SET DEFAULT " + DataTypeFactory.getInstance().fromObject(defaultValue, database).objectToSql(defaultValue, database),
                        getAffectedColumn(statement))
         };
     }


### PR DESCRIPTION
Reverts dbmanul/dbmanul#18

Need to revert this because it breaks integration tests. Also, it requires specifying the columnType, which is an inconvenience for the end user. I want to try and find an alternative for requiring it.