### PR TITLE
[CORE-3009] ASANY Drop Default Value failed (upstream pr #659)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
@@ -70,8 +70,10 @@ public class DropDefaultValueGenerator extends AbstractSqlGenerator<DropDefaultV
             sql = "ALTER TABLE " + escapedTableName + " ALTER " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DROP DEFAULT";
         } else if (database instanceof OracleDatabase) {
             sql = "ALTER TABLE " + escapedTableName + " MODIFY " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DEFAULT NULL";
-        } else if (database instanceof SybaseASADatabase || database instanceof SybaseDatabase) {
+        } else if (database instanceof SybaseDatabase) {
              sql = "ALTER TABLE " + escapedTableName + " REPLACE " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DEFAULT NULL";
+        } else if (database instanceof SybaseASADatabase) {
+            sql = "ALTER TABLE " + escapedTableName + " ALTER " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DEFAULT NULL";
         } else if (database instanceof DerbyDatabase) {
             sql = "ALTER TABLE " + escapedTableName + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " WITH DEFAULT NULL";
         } else if (database instanceof InformixDatabase) {


### PR DESCRIPTION
According to http://dcx.sap.com/index.html#sqla170/en/html/8169d7966ce2101497b5ac611f7413ce.html , the currently used ALTER TABLE ... ALTER ... REPLACE syntax is for SAP Adaptive Server Enterprise (ASE), not for SQL Anywhere.