### PR TITLE
Prevent liquibase.exception.DatabaseException (upstream pr#686)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -748,9 +748,11 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
+                    if (database instanceof DB2Database && ((DB2Database)database).getDataServerType() == DataServerType.DB2I) {
+                        return queryDB2I(schema, view);
+                    }
                     return extract(databaseMetaData.getTables(catalog, schema, view, new String[]{"VIEW"}));
                 }
-
 
                 @Override
                 public List<CachedRow> bulkFetchQuery() throws SQLException, DatabaseException {
@@ -762,7 +764,19 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
+                    if (database instanceof DB2Database && ((DB2Database)database).getDataServerType() == DataServerType.DB2I) {
+                        return queryDB2I(schema, null);
+                    }
                     return extract(databaseMetaData.getTables(catalog, schema, null, new String[]{"VIEW"}));
+                }
+
+
+                private List<CachedRow> queryDB2I(String schema, String view) throws DatabaseException, SQLException {
+                    String sql = "SELECT TABLE_CATALOG as TABLE_CAT, TABLE_SCHEMA as TABLE_SCHEM, TABLE_NAME, VIEW_DEFINITION as OBJECT_BODY FROM SYSIBM.VIEWS WHERE TABLE_SCHEMA='" + schema + "'";
+                    if (view != null) {
+                        sql += " AND TABLE_NAME='" + view + "'";
+                    }
+                    return executeAndExtract(sql, database);
                 }
 
                 private List<CachedRow> queryOracle(CatalogAndSchema catalogAndSchema, String viewName) throws DatabaseException, SQLException {


### PR DESCRIPTION
…00://xx.xx.xx/schema view with liquibase.statement.core.GetViewDefinitionStatement

At least on our system AS400JDBCDatabaseMetaData.getTables called to get views and view = null return a lot of of entries that are not really views.
For reference we use jtopen 9.3 against a v7r1 IBM i system.
The new code has the added bonus of returning OBJECT_BODY in the same query.