### PR TITLE
[CORE-1225] [pr#723] - add commandline support

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -84,6 +84,7 @@ public class Main {
     protected String liquibaseSchemaName;
     protected String databaseChangeLogTableName;
     protected String databaseChangeLogLockTableName;
+    protected String databaseChangeLogTablespaceName;
     protected String defaultCatalogName;
     protected String changeLogFile;
     protected String overwriteOutputFile;
@@ -873,6 +874,8 @@ public class Main {
                 this.databaseClass, this.driverPropertiesFile, this.propertyProviderClass,
                 this.liquibaseCatalogName, this.liquibaseSchemaName, this.databaseChangeLogTableName,
                 this.databaseChangeLogLockTableName);
+        database.setLiquibaseTablespaceName(this.databaseChangeLogTablespaceName);
+
         try {
 
             boolean includeCatalog = Boolean.parseBoolean(getCommandParam(OPTIONS.INCLUDE_CATALOG, "false"));

--- a/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -603,6 +603,7 @@ public class MainTest {
                 "--changeLogFile=FILE",
                 "--classpath=CLASSPATH;CLASSPATH2",
                 "--contexts=CONTEXT1,CONTEXT2",
+                "--databaseChangeLogTablespaceName=MYTABLES",
                 "tag", "TagHere"
         };
 
@@ -616,6 +617,7 @@ public class MainTest {
         assertEquals("Command line option --changeLogFile is parsed correctly", "FILE", cli.changeLogFile);
         assertEquals("Command line option --classpath is parsed correctly", "CLASSPATH;CLASSPATH2", cli.classpath);
         assertEquals("Command line option --contexts is parsed correctly", "CONTEXT1,CONTEXT2", cli.contexts);
+        assertEquals("Command line option --databaseChangeLogTablespaceName is parsed correctly", "MYTABLES", cli.databaseChangeLogTablespaceName);
         assertEquals("Main command 'tag' is parsed correctly", "tag", cli.command);
         assertEquals("Command parameter 'TagHere' is parsed correctly", "TagHere", cli.commandParams.iterator().next());
     }


### PR DESCRIPTION
- Supports setting the tablespace for DATABASECHANGELOG and -lock through the command line.